### PR TITLE
Optimize analytics loading and defer utility bar

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -41,25 +41,32 @@ export const metadata = {
   robots: { index: true, follow: true },
 };
 
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_ID || "G-J5YK10YLLC";
+const DEFAULT_GA_ID = "G-J5YK10YLLC";
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_ID?.trim() || DEFAULT_GA_ID;
+const IS_GA_ENABLED = Boolean(GA_MEASUREMENT_ID);
 
 export default function RootLayout({ children }) {
   return (
     <html lang="tr" dir="ltr" className={inter.className}>
       <body className="min-h-screen bg-white text-neutral-900 antialiased">
         {/* Google Analytics */}
-        <Script
-          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
-          strategy="lazyOnload"
-        />
-        <Script id="ga-init" strategy="lazyOnload">
-          {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${GA_MEASUREMENT_ID}', { anonymize_ip: true });
-          `}
-        </Script>
+        {IS_GA_ENABLED && (
+          <>
+            <Script
+              id="gtag-lib"
+              src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+              strategy="afterInteractive"
+            />
+            <Script id="ga-init" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${GA_MEASUREMENT_ID}', { anonymize_ip: true });
+              `}
+            </Script>
+          </>
+        )}
 
         {/* Skip link: tek hedef -> #main-content */}
         <a

--- a/components/UtilityBar.client.js
+++ b/components/UtilityBar.client.js
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 
 const UtilityBar = dynamic(() => import("./UtilityBar"), {
@@ -8,5 +9,27 @@ const UtilityBar = dynamic(() => import("./UtilityBar"), {
 });
 
 export default function UtilityBarClient() {
+  const [shouldRender, setShouldRender] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const scheduleRender = () => setShouldRender(true);
+
+    if ("requestIdleCallback" in window) {
+      const idleId = window.requestIdleCallback(scheduleRender, { timeout: 2000 });
+      return () => {
+        if ("cancelIdleCallback" in window) {
+          window.cancelIdleCallback(idleId);
+        }
+      };
+    }
+
+    const timerId = window.setTimeout(scheduleRender, 1200);
+    return () => window.clearTimeout(timerId);
+  }, []);
+
+  if (!shouldRender) return null;
+
   return <UtilityBar />;
 }


### PR DESCRIPTION
## Summary
- ensure Google Analytics only loads once and after interaction to avoid duplicate tag manager requests
- delay mounting the accessibility utility bar until the browser is idle to reduce long main-thread tasks

## Testing
- npm run lint (fails: Invalid project directory provided, no such directory: /workspace/sahneva12/lint)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912773142f08321a173a6ef9050b77c)