### PR TITLE
Defer GA loading and bypass hero image optimization

### DIFF
--- a/app/(site)/page.js
+++ b/app/(site)/page.js
@@ -268,11 +268,11 @@ export default function HomePage() {
             alt="Profesyonel sahne kurulumu, LED ekranlar ve ses-ışık sistemleri - Sahneva"
             fill
             priority
-            fetchPriority="high"
             quality={70}
             sizes="100vw"
             placeholder="blur"
             loading="eager"
+            unoptimized
             className="object-cover object-center"
             style={{
               /* LCP için transform kaldırıldı */

--- a/app/layout.js
+++ b/app/layout.js
@@ -55,9 +55,9 @@ export default function RootLayout({ children }) {
             <Script
               id="gtag-lib"
               src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
-              strategy="afterInteractive"
+              strategy="lazyOnload"
             />
-            <Script id="ga-init" strategy="afterInteractive">
+            <Script id="ga-init" strategy="lazyOnload">
               {`
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
## Summary
- load Google Analytics with the lazyOnload strategy so the tracking scripts wait until after the initial page work
- serve the homepage hero background image without the Next.js optimizer to remove the early _next/image request from the critical path

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/sahneva12/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127d3d4b7483218e4bda5985f39ab5)